### PR TITLE
Regular? ToC behavior of including first line only

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -70,6 +70,8 @@ const renderToc = async (tocBlocks, slot, tocId, uuid, parentPage) => {
   for (let i = 0; i < tocBlocks.length; i++) {
     let blockContent = tocBlocks[i].content;
 
+    blockContent = blockContent.substring(0, blockContent.indexOf("\n"));
+
     if (blockContent.includes("((") && blockContent.includes("))")) {
       // Get content if it's q block reference
       const rxGetId = /\(([^(())]+)\)/;


### PR DESCRIPTION
I use metadata in the heading sometimes, which gets included into the ToC.

Presently, the only metadata being filtered is "id:: ".

But I believe that only including the first line is the best way to solve this, since it's standard behviour in most markdown editors I've used to only grab that first line when generating the ToC. For further reference, even Logseq doesn't style consecutive lines with the same font-size when using the heading syntax.

I hope it makes sense :)

Thank you for the plugin!