### PR TITLE
fix: consider [[test]] and [I'm test]([[test]])

### DIFF
--- a/src/features/PageToc.tsx
+++ b/src/features/PageToc.tsx
@@ -31,6 +31,8 @@ const PageToc = ({
           /#powerblocks-button|#powerblocks|(.+?)::\s*([^\n]*)|^#+\s/g,
           '',
         )
+        .replace(/\[([^\]]+)\]\(\[([^\)]+)\]\)/g, '$1')
+        .replace(/\[\[([^\]]+)\]\]/g, '$1')
         .trim()
 
       // Reset nesting if stack is more than current level


### PR DESCRIPTION
Take into account the display of two special cases.
![image](https://github.com/user-attachments/assets/1160c7eb-d61c-4619-9f43-6ae652548d53)
![image](https://github.com/user-attachments/assets/1116e0ea-0381-406f-a382-10fb1100cac8)

I think it is a optimization on display.