### PR TITLE
Collapsible TOC for Enhanced Usability

### DIFF
--- a/src/features/PageToc.tsx
+++ b/src/features/PageToc.tsx
@@ -1,6 +1,30 @@
-import { ReactElement } from 'react'
+import { ReactElement, useEffect, useState } from 'react';
 
 import { HeaderInterface } from '../libs/get-headers-arr'
+
+type VisibilityState = Record<string, boolean>;
+
+const headerLevelConversion = (item: HeaderInterface, numbering: number[]) => {
+  if (!item.content) return;
+
+  const level = item.content.split(' ')[0]!.length; // Get number of #
+
+  if (numbering.length < level) {
+    // If the current level is greater than the length of numbering, add a new sub-level
+    numbering.push(1);
+  } else if (numbering.length === level) {
+    // If the current level is the same, increment the last number
+    numbering[numbering.length - 1]!++;
+  } else {
+    // If the current level is less, cut off the deeper levels and increment the current level
+    numbering.splice(level);
+    numbering[numbering.length - 1]!++;
+  }
+
+  const pathIndices = numbering.join("-");
+
+  return { pathIndices, level };
+};
 
 const PageToc = ({
   pageName,
@@ -9,10 +33,112 @@ const PageToc = ({
   pageName: string
   data: HeaderInterface[]
 }) => {
-  if (data.length == 0) return
+  if (data.length === 0 || data.every(item => !item.content)) {
+    return null; // Don't render TOC if no headers
+  }
+  const [visibility, setVisibility] = useState<VisibilityState>({});
+
+  useEffect(() => {
+    const initialVisibility: VisibilityState = {};
+    const numbering: number[] = [];
+    data.forEach((item) => {
+      const result = headerLevelConversion(item, numbering);
+      initialVisibility[result!.pathIndices] = true; // Default all to visible initially
+    });
+    setVisibility(initialVisibility);
+  }, [data]);
+
+  const collapseChildVisibility = (parentKey: string) => {
+    const updatedVisibility = { ...visibility };
+
+    const allFalse = Object.keys(updatedVisibility)
+      .filter(key => key.startsWith(`${parentKey}-`) && key != '0')
+      .every(key => updatedVisibility[key] === false);
+
+    Object.keys(updatedVisibility).forEach(key => {
+      // Check if the current key is a descendant of the parentKey
+      if (key.startsWith(`${parentKey}-`) && key != '0') {
+        if (updatedVisibility[parentKey] === true && updatedVisibility[key] === false && !allFalse) {
+          updatedVisibility[key] = false; // check the special case that some children are already collapsed
+        } else {
+          updatedVisibility[key] = !updatedVisibility[key];
+        }
+      }
+    });
+
+    setVisibility(updatedVisibility);
+  };
 
   const goToHeader = (uuid: string) => {
     logseq.Editor.scrollToBlockInPage(pageName, uuid, { replaceState: true })
+  }
+
+  const generateCollapsibleTOC = () => {
+    const toc: ReactElement[] = []
+    const stack: number[] = []
+    const numbering: number[] = []
+
+    data.forEach((item, index) => {
+      const result = headerLevelConversion(item, numbering);
+      // Remove #, and other properties from the content
+      const content = item.content
+        .replace(
+          /#powerblocks-button|#powerblocks|(.+?)::\s*([^\n]*)|^#+\s/g,
+          '',
+        )
+        .trim()
+
+      const hasChild = data.some((child, childIndex) => {
+        if (!child || !child.content) {
+          return false;
+        }
+
+        const childLevel = child.content.split(' ')[0]?.length || 1;
+        const isDirectChild = childLevel > (result!.level ?? 0);  // Check if the child is nested deeper than the current level
+        const isAfterCurrent = childIndex > index; // Ensure it is after the current item
+
+        return isDirectChild && isAfterCurrent;
+      });
+
+      // Reset nesting if stack is more than current level
+      while (stack.length > 0 && stack[stack.length - 1]! >= result!.level) {
+        stack.pop()
+      }
+      stack.push(result!.level)
+
+      if (visibility[result!.pathIndices]) {
+        const isChildrenVisible = Object.keys(visibility).some(
+          childKey => childKey.startsWith(`${result!.pathIndices}-`) && visibility[childKey]
+        );
+
+        const collapseIcon = hasChild ? (isChildrenVisible ? logseq.settings?.collapseIcon[1] : logseq.settings?.collapseIcon[0]) : logseq.settings?.collapseIcon[0];
+
+        toc.push(
+          <li key={item.uuid} className={`toc-item indent-${result!.level}`}>
+            {(result!.level ?? 0) > 0 && (
+              logseq.settings?.hideCollapseIcon ? (
+                <button
+                  className="button-light"
+                  onClick={() => collapseChildVisibility(result!.pathIndices)}>
+                  {collapseIcon}
+                </button>
+              ) : (
+                <button
+                  className="button-light"
+                  style={{ opacity: 0.4 }}
+                  onClick={() => collapseChildVisibility(result!.pathIndices)}>
+                  {collapseIcon}
+                </button>
+              )
+            )
+            }
+            <span className="icon-text-spacer"></span>
+            <span onClick={() => goToHeader(item.uuid)}>{content}</span>
+          </li >
+        );
+      }
+    })
+    return toc
   }
 
   const generateTOC = () => {
@@ -54,9 +180,10 @@ const PageToc = ({
   return (
     <nav className="toc">
       <div className="toc-header">{logseq.settings!.tocTitle}</div>
-      <ul>{generateTOC()}</ul>
+      {logseq.settings!.collapsibleTOC ? <ul>{generateCollapsibleTOC()}</ul> : <ul>{generateTOC()}</ul>}
     </nav>
   )
 }
 
 export default PageToc
+

--- a/src/features/page-toc.css
+++ b/src/features/page-toc.css
@@ -33,3 +33,18 @@
 .indent-4 { margin-left: 4.5em; }
 .indent-5 { margin-left: 6em; }
 .indent-6 { margin-left: 7.5em; }
+
+.icon-text-spacer {
+    margin-right: 0.25em; 
+}
+
+.button-light {
+  color: #0645ad;
+  opacity: 0;
+  transition: opacity 0.2s ease, color 0.2s ease;
+}
+
+.toc-item:hover .button-light {
+  opacity: 0.7 !important;
+  color: #0645ad; 
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,5 +1,10 @@
 import { SettingSchemaDesc } from '@logseq/libs/dist/LSPlugin.user'
 
+const iconPairs = [
+  ['▶', '▼'],
+  ['▷', '▽'],
+];
+
 export const settings: SettingSchemaDesc[] = [
   {
     key: 'pageLevelToc',
@@ -24,4 +29,27 @@ export const settings: SettingSchemaDesc[] = [
       'If set to true, clicking on a section header will open the block in a new page. If false, clicking on the section header will scroll to the block on the same page.',
     title: 'Open block in new page',
   },
+  {
+    key: 'collapsibleTOC',
+    type: 'boolean',
+    default: true,
+    description:
+      'True makes the table of contents collapsible; false makes it fixed.',
+    title: 'collapsible Table of Contents',
+  },
+  {
+    key: 'collapseIcon',
+    type: 'enum',
+    title: 'Collapse Icon',
+    description: 'Sets the icon for collapsing the table of contents.',
+    enumChoices: iconPairs.map(pair => `${pair[0]}${pair[1]}`),
+    default: '▶, ▼'
+  },
+  {
+    key: 'hideCollapseIcon',
+    type: 'boolean',
+    default: false,
+    description: 'Hides the collapse icon when not hovering',
+    title: 'Hide Collapse Icon',
+  }
 ]


### PR DESCRIPTION
First of all, thank you for maintaining such a great plugin! It has been incredibly helpful for long-page reading in Logseq, and I wanted to contribute an enhancement that I believe will further improve the user experience.

I’ve added a collapsible **Table of Contents (TOC)** feature that allows users to hide lower-level headers and focus on the main structure of the page, making navigation simpler and more efficient.

**New Features**
- **Collapsible TOC**
  - The TOC is now collapsible, helping users declutter long pages.
- **Customization Options**
  - Enable or disable the collapsible TOC based on user preference.
  - Customize the toggle icon for expanding or collapsing sections.
  - Option to hide the toggle icon when not hovering, for a cleaner interface.

**Backward Compatibility**
  - The new features are backward compatible, ensuring that users who prefer the previous behavior (non-collapsible TOC) can continue using the plugin without any changes required.

I hope you find this feature useful, and I’m happy to make any adjustments based on your feedback! Here is a demo clip showcasing the functionality.

https://github.com/user-attachments/assets/5f2f1ecd-4429-4922-af17-d6539efefc93