### PR TITLE
Format markdown and logseq links

### DIFF
--- a/src/features/PageToc.tsx
+++ b/src/features/PageToc.tsx
@@ -27,11 +27,20 @@ const PageToc = ({
       const level = item.content.split(' ')[0]!.length
       // Remove #, and other properties from the content
       const content = item.content
-        .replace(
+        ?.replace(
           /#powerblocks-button|#powerblocks|(.+?)::\s*([^\n]*)|^#+\s/g,
           '',
         )
-        .trim()
+        // Remove markdown links for 1, 2, and 3 parentheses
+        ?.replace(/\[([^\]]+)\]\([^()]+\)/g, '$1')
+        ?.replace(/\[([^\]]+)\]\(\([^()]+\)\)/g, '$1')
+        ?.replace(/\[([^\]]+)\]\(\(\([^()]+\)\)\)/g, '$1')
+        // remove logseq links (2 and 3 parentheses)
+        ?.replace(/\(\(\([^()]*\)\)\)/g, '')
+        ?.replace(/\(\([^()]*\)\)/g, '')
+        // Get first line and trim
+        ?.split('\n')[0]
+        ?.trim() ?? ''
 
       // Reset nesting if stack is more than current level
       while (stack.length > 0 && stack[stack.length - 1]! >= level) {


### PR DESCRIPTION
I sometimes use markdown / logseq links in titles, which becomes very messy:
<img width="718" height="624" alt="Screenshot 2025-09-15 at 6 38 25 pm" src="https://github.com/user-attachments/assets/53ef32be-4e8d-4568-a946-07b598d064e4" />
This removes the link URL / UUIDs but keeping the titles, also removing everything after the first line break:
<img width="717" height="408" alt="Screenshot 2025-09-15 at 6 39 41 pm" src="https://github.com/user-attachments/assets/bd64e6db-d5ac-447f-aed6-732b6613c86f" />
